### PR TITLE
Update blowout rule logic & misc cleanup

### DIFF
--- a/rankings/rankings.csv
+++ b/rankings/rankings.csv
@@ -1,94 +1,100 @@
 team,rating_team,rank
-Scandal,2213,1
-Phoenix,2016,2
-Traffic,1995,3
-Molly Brown,1961,4
-BENT,1830,5
-Fury,1713,6
-Siege,1712,7
-Nemesis,1702,8
-Flipside,1697,9
-Seattle Riot,1694,10
-Grit,1648,11
-Pop,1564,12
-Iris,1562,13
-Parcha,1534,14
-Flight,1502,15
-Schwa,1501,16
-Nightlock,1480,17
-Indy Rogue,1450,18
-Sage,1449,19
-Ozone,1427,20
-Heist,1369,21
-Vengeance,1340,22
-Tabby Rosa,1322,23
-Molly Blue,1291,24
-Underground,1269,25
-Wicked,1233,26
-Agency,1201,27
-Banshee,1199,28
-Wildfire,1199,29
-Dish,1185,30
-Oregon Downpour,1184,31
-Huntsville Laika,1175,32
-Rival,1155,33
-Stellar,1139,34
-LOL,1137,35
-Colorado Small Batch,1133,36
-KnoxFusion,1119,37
-Juice Box,1109,38
-Crush City,1096,39
-Vintage,1093,40
-remix,1044,41
-Brooklyn Book Club,1003,42
-Wave,1000,43
-Seattle END,998,44
-Trainwreck,996,45
-FAB,995,46
-Venus,973,47
-Y'all,909,48
-Drift,887,49
-Rip Tide,887,50
-Medusa,857,51
-Pine Baroness,856,52
-Hayride,850,53
-Vice,842,54
-Stormborn,832,55
-Magma,831,56
-Fiasco,824,57
-Rampage,816,58
-Autonomous,806,59
-Shiver,797,60
-San Antonio Problems,768,61
-Void Cat Rewind,760,62
-Steel,759,63
-Seven Devils,755,64
-Virginia Rebellion,712,65
-Twisted Womxn,691,66
-Portland Rain Check,678,67
-Sureshot,669,68
-Warhawks,667,69
-PLOW,653,70
-Freshwater Ultimate,642,71
-Minnesota Superior A,589,72
-Colorado Cutthroat: Youth Club U-20 Girls,583,73
-TWISTED,573,74
-Tempest,540,75
-Venom,522,76
-Jackwagon,515,77
-Calypso,510,78
-cATLanta,498,79
-Seattle Soul,451,80
-Off Their Rockers,432,81
-Frolic,425,82
-Haboob,418,83
-Solstice,406,84
-Ultraviolet,397,85
-Bullseye,392,86
-Firewheel,375,87
-Dissent,317,88
-Just Add Water,276,89
-Tempo,230,90
-Inferno,181,91
-Versa,152,92
-Ignite,138,93
+Scandal,2722,1
+Fury,2445,2
+Brute Squad,2426,3
+Molly Brown,2403,4
+Phoenix,2313,5
+Flipside,2305,6
+Traffic,2190,7
+BENT,2177,8
+6ixers,2126,9
+Schwa,2096,10
+Grit,2001,11
+Seattle Riot,1989,12
+Nemesis,1975,13
+Iris,1884,14
+Starling Ultimate,1883,15
+Parcha,1845,16
+Siege,1782,17
+Nightlock,1755,18
+Vengeance,1741,19
+Flight,1667,20
+Tabby Rosa,1659,21
+Sage,1642,22
+Ozone,1580,23
+Pop,1522,24
+Crush City,1475,25
+Rival,1454,26
+Indy Rogue,1450,27
+Underground,1428,28
+Colorado Small Batch,1366,29
+Agency,1257,30
+Oregon Downpour,1238,31
+Molly Blue,1219,32
+Vintage,1186,33
+Wave,1180,34
+Brooklyn Book Club,1173,35
+Heist,1163,36
+Venus,1147,37
+Wildfire,1140,38
+Huntsville Laika,1136,39
+Hayride,1079,40
+Zephyr,1064,41
+Vice,1055,42
+remix,984,43
+LOL,965,44
+Wicked,942,45
+Seattle END,939,46
+Juice Box,910,47
+Stellar,891,48
+Shiver,882,49
+FAB,865,50
+Dish,854,51
+PLOW,849,52
+Rip Tide,843,53
+Drift,827,54
+Trainwreck,826,55
+Virginia Rebellion,823,56
+San Antonio Problems,817,57
+Banshee,760,58
+Warhawks,754,59
+Incline,745,60
+Pine Baroness,733,61
+Fiasco,659,62
+Rampage,654,63
+Steel,616,64
+Seven Devils,588,65
+Tempest,585,66
+Frolic,568,67
+Void Cat Rewind,559,68
+Magma,548,69
+KnoxFusion,513,70
+TWISTED,485,71
+cATLanta,484,72
+Portland Rain Check,446,73
+Colorado Cutthroat: Youth Club U-20 Girls,428,74
+Stormborn,428,75
+Calypso,401,76
+Medusa,395,77
+Autonomous,347,78
+Venom,304,79
+Ignite,287,80
+Jackwagon,262,81
+Versa,227,82
+Firewheel,221,83
+Twisted Womxn,219,84
+Freshwater Ultimate,195,85
+Notorious C.L.E.,194,86
+Y'all,191,87
+Off Their Rockers,172,88
+Haboob,168,89
+Dissent,148,90
+Ultraviolet,122,91
+Seattle Soul,78,92
+Minnesota Superior A,9,93
+Sureshot,-52,94
+Tempo,-68,95
+Just Add Water,-134,96
+Inferno,-300,97
+Solstice,-415,98
+Bullseye,-526,99

--- a/rankings/rating.R
+++ b/rankings/rating.R
@@ -9,10 +9,11 @@ first_week <- lubridate::week("2023-06-01")
 last_week <- lubridate::week("2023-09-19")
 week_diff <- last_week - first_week
 date_weight_diff <- 0.5 / week_diff
+week_n <- length(first_week:last_week)
 date_weight_tbl <-
   tibble(
     week = first_week:last_week,
-    date_weight = seq(0.5, 1, date_weight_diff)
+    date_weight = scales::rescale(exp(1:week_n / week_n), c(.5, 1))
   )
 
 scores_raw <-

--- a/rankings/rating.R
+++ b/rankings/rating.R
@@ -83,8 +83,8 @@ scores_weighted <-
         !team_1_won & score_2 > score_1 * 2 + 1 ~ TRUE,
         TRUE ~ FALSE
       )
-  ) %>% 
-  ungroup() %>% 
+  ) %>%
+  ungroup() %>%
   mutate(
     game_number = row_number()
   ) %>%

--- a/rankings/rating.R
+++ b/rankings/rating.R
@@ -184,12 +184,10 @@ scores <-
       select(team, n_games)
   )
 i <- 1
+mean_ratings_diff <- 0
 
 # Keep looping through and re-rating until the ratings stabilize
-while (i < max_iterations & !identical(
-  rankings_old %>% select(team, rank),
-  rankings_new %>% select(team, rank)
-)) {
+while (i < max_iterations & !between(mean_ratings_diff, .9999, 1.0001)) {
   # See how many differences in rankings this last iteration produced
   n_diffs <-
     anti_join(
@@ -324,6 +322,13 @@ while (i < max_iterations & !identical(
     )
 
   print(ratings_new)
+
+  mean_ratings_diff <-
+    mean(
+      arrange(ratings_new, team)$rating_team /
+        arrange(ratings_old, team)$rating_team,
+      na.rm = TRUE
+    )
 
   i <- i + 1
 }

--- a/rankings/rating.R
+++ b/rankings/rating.R
@@ -269,7 +269,6 @@ while (i < max_iterations & !between(mean_ratings_diff, .9999, 1.0001)) {
         semi_join(n_blowouts_to_remove, by = c("team")) %>%
         filter(blowout) %>%
         select(
-          team,
           game_number
         )
     } else {
@@ -285,7 +284,7 @@ while (i < max_iterations & !between(mean_ratings_diff, .9999, 1.0001)) {
   # Use the `game_number` to remove blowouts
   scores_filtered <-
     scores_joined %>%
-    anti_join(blowouts_to_remove, by = c("game_number", "team"))
+    anti_join(blowouts_to_remove, by = c("game_number"))
 
   # Re-calc the team average ratings
   ratings_new <-

--- a/rankings/rating.R
+++ b/rankings/rating.R
@@ -8,14 +8,14 @@ max_iterations <- 10000
 first_week <- lubridate::week("2023-06-01")
 last_week <- lubridate::week("2023-09-19")
 week_diff <- last_week - first_week
-date_weight_diff <- 0.5/week_diff
-date_weight_tbl <- 
+date_weight_diff <- 0.5 / week_diff
+date_weight_tbl <-
   tibble(
     week = first_week:last_week,
     date_weight = seq(0.5, 1, date_weight_diff)
   )
 
-scores_raw <- 
+scores_raw <-
   readr::read_csv(
     glue::glue(here::here("rankings/scores.csv")),
     col_types = "ccii"
@@ -24,17 +24,18 @@ scores_raw <-
 us_teams <- readr::read_csv(here::here("rankings/us_teams.csv"))
 
 # Filter games to just US teams
-scores_us <- 
-  scores_raw %>% 
+scores_us <-
+  scores_raw %>%
   filter(
     team_1 %in% us_teams$team &
       team_2 %in% us_teams$team
   )
 
 # Rating differential function
-diff_function <- function(r) {
-  125 + 475 * ((sin(min(1, (1 - r)/0.5) * 0.4 * pi)) / sin(0.4 * pi))
-}
+diff_function <-
+  function(r) {
+    125 + 475 * ((sin(min(1, (1 - r) / 0.5) * 0.4 * pi)) / sin(0.4 * pi))
+  }
 
 # Used in rating differential
 r_function <- function(w, l) {
@@ -42,21 +43,25 @@ r_function <- function(w, l) {
 }
 
 # Score weight function where w is winner score and l is loser score
-score_weight_function <- function(w, l) {
-  min(1, sqrt((w + max(l, floor((w - 1)/2))) / 19))
-}
+score_weight_function <-
+  function(
+    w,
+    l
+  ) {
+    min(1, sqrt((w + max(l, floor((w - 1) / 2))) / 19))
+  }
 
-# For each game, add score weights, date weights, and get the abs value of the 
+# For each game, add score weights, date weights, and get the abs value of the
 # rating differential
-scores_weighted <- 
-  scores_us %>% 
-  rowwise() %>% 
+scores_weighted <-
+  scores_us %>%
+  rowwise() %>%
   mutate(
     team_1_won = score_1 > score_2,
     week = lubridate::week(date),
-    score_weight = 
+    score_weight =
       case_when(
-        # If either team scored >= 13 points or combined score was >= 19, 
+        # If either team scored >= 13 points or combined score was >= 19,
         # the score weight is 1
         score_1 >= 13 | score_2 >= 13 | score_1 + score_2 >= 19 ~ 1,
         # Otherwise if team 1 won, apply score weight function
@@ -65,14 +70,14 @@ scores_weighted <-
         TRUE ~ score_weight_function(score_2, score_1)
       ),
     # Get r variable used in rating differential function
-    r = 
+    r =
       case_when(
         team_1_won ~ r_function(score_1, score_2),
         TRUE ~ r_function(score_2, score_1)
       ),
     # Get the rating differential for this game
     rating_diff_absolute = diff_function(r),
-    blowout_score = 
+    blowout_score =
       case_when(
         team_1_won & score_1 > score_2 * 2 + 1 ~ TRUE,
         !team_1_won & score_2 > score_1 * 2 + 1 ~ TRUE,
@@ -82,217 +87,245 @@ scores_weighted <-
   ungroup() %>% 
   mutate(
     game_number = row_number()
-  ) %>% 
+  ) %>%
   # Attach date weights
-  inner_join(date_weight_tbl) %>% 
+  inner_join(date_weight_tbl) %>%
   mutate(
     # Game weight is product of score weight and date weight
     weight = score_weight * date_weight
-  ) %>% 
+  ) %>%
   select(
     game_number,
     starts_with("team"),
     starts_with("score"),
     ends_with("weight"),
-    rating_diff_absolute, everything()
+    rating_diff_absolute,
+    everything()
   )
 
 # Make 2 rows per game -- one per team -- so now we have team and opponent
-scores_long <- 
+scores_long <-
   bind_rows(
-    scores_weighted %>% 
+    scores_weighted %>%
       rename(
         team = team_1,
         opponent = team_2,
         score_team = score_1,
         score_opponent = score_2
-      ) %>% 
+      ) %>%
       select(-team_1_won),
-    scores_weighted %>% 
+    scores_weighted %>%
       rename(
         team = team_2,
         opponent = team_1,
         score_team = score_2,
         score_opponent = score_1
-      ) %>% 
+      ) %>%
       select(-team_1_won)
-  ) %>% 
+  ) %>%
   arrange(game_number)
 
 # Apply the positive or negative rating differential to get an initial
 # game rating for each game
-scores_initial <- 
-  scores_long %>% 
+scores_initial <-
+  scores_long %>%
   # Start at baseline rating 1000 for every team
   mutate(
     rating_opponent = 1000,
-    rating_diff = 
+    rating_diff =
       case_when(
         score_team > score_opponent ~ rating_diff_absolute,
         TRUE ~ rating_diff_absolute * -1
       ),
     rating_game = rating_opponent + rating_diff
-  ) %>% 
+  ) %>%
   select(
-    game_number, team, opponent, weight, 
-    rating_opponent, rating_diff, rating_game,
+    game_number,
+    team,
+    opponent,
+    weight,
+    rating_opponent,
+    rating_diff,
+    rating_game,
     blowout_score
   )
 
 # Initial weighted average of game ratings per team to get team ratings
-ratings_initial <- 
-  scores_initial %>% 
-  group_by(team) %>% 
+ratings_initial <-
+  scores_initial %>%
+  group_by(team) %>%
   summarise(
     # Round to nearest whole number
     rating_team = rating_game %>% weighted.mean(weight) %>% round(),
     n_games = n()
-  ) %>% 
+  ) %>%
   arrange(desc(rating_team))
 
 # Initialize ratings and scores for the loop
 ratings_old <- ratings_initial %>% select(-n_games)
-ratings_new <- tibble(team = character(), rating_team = double(), n_games = integer())
-rankings_old <- 
-  ratings_old %>% 
+ratings_new <-
+  tibble(
+    team = character(),
+    rating_team = double(),
+    n_games = integer()
+  )
+rankings_old <-
+  ratings_old %>%
   mutate(
     rank = row_number()
   )
-rankings_new <- tibble(team = character(), rating_team = double(), rank = integer())
-scores <- 
-  scores_initial %>% 
+rankings_new <-
+  tibble(team = character(), rating_team = double(), rank = integer())
+scores <-
+  scores_initial %>%
   inner_join(
-    ratings_initial %>% 
+    ratings_initial %>%
       select(team, n_games)
   )
 i <- 1
 
 # Keep looping through and re-rating until the ratings stabilize
-while (i < max_iterations & 
-       !identical(rankings_old %>% select(team, rank), rankings_new  %>% select(team, rank))) {
-  
+while (i < max_iterations & !identical(
+  rankings_old %>% select(team, rank),
+  rankings_new %>% select(team, rank)
+)) {
   # See how many differences in rankings this last iteration produced
-  n_diffs <- 
+  n_diffs <-
     anti_join(
-      rankings_old, 
+      rankings_old,
       rankings_new,
       by = c("team", "rank")
-    ) %>% 
+    ) %>%
     nrow()
-  
-  message(glue::glue("On iteration {i}. % difference: {n_diffs}/{nrow(ratings_old)} = {round(n_diffs/nrow(ratings_old), 2) * 100}%"))
-  
+
+  message(
+    glue::glue(
+      "On iteration {i}. % difference: {n_diffs}/{nrow(ratings_old)} = {round(n_diffs/nrow(ratings_old), 2) * 100}%"
+    )
+  )
+
   # If this isn't the first iteration, set the team ratings we just calculated
   # to `ratings_old` so we can re-calculate new ratings and see if they match
   if (nrow(ratings_new) > 0) {
     ratings_old <- ratings_new
     rankings_old <- rankings_new
   }
-  
+
   # Attach each opponent's latest rating to game scores
-  scores_joined <- 
-    scores %>% 
-    select(-rating_opponent, -rating_game) %>% 
+  scores_joined <-
+    scores %>%
+    select(-rating_opponent, -rating_game) %>%
     # Attach each opponent's ratings from the last iteration
     inner_join(
-      ratings_old %>% 
+      ratings_old %>%
         rename(
           rating_opponent = rating_team,
           opponent = team
         ),
       by = "opponent"
-    ) %>% 
+    ) %>%
     # Attach team's latest rating for blowout rule calc & n games
     inner_join(
       ratings_old,
       by = "team"
-    ) %>% 
+    ) %>%
     # Get the latest game rating given the new opponent team rating
     # (game `rating_diff` stays constant)
     mutate(
       rating_game = rating_opponent + rating_diff,
-      # Add a boolean for whether each game was a blowout given 
+      # Add a boolean for whether each game was a blowout given
       # each team's new rating
-      blowout = 
+      blowout =
         case_when(
-          # TODO: figure out if this should also be 
-          # `rating_team - rating_opponent < -600` (aka when your team is way 
+          # TODO: figure out if this should also be
+          # `rating_team - rating_opponent < -600` (aka when your team is way
           # worse than the other team do we still count the blowout)
           rating_team - rating_opponent > 600 & blowout_score ~ TRUE,
           TRUE ~ FALSE
         )
-    ) 
-  
-  # There are new games that are designated as blowouts because we've 
+    )
+
+  # There are new games that are designated as blowouts because we've
   # re-calculated every team's rating. So count number of new blowouts per team
-  n_blowouts <- 
-    scores_joined %>% 
-    group_by(team) %>% 
+  n_blowouts <-
+    scores_joined %>%
+    group_by(team) %>%
     summarise(n_blowouts = sum(blowout))
-  
+
   # Get a dataframe of how many blowouts to remove per team, if not 0
-  n_blowouts_to_remove <- 
-    scores_joined %>% 
-    rowwise() %>% 
-    distinct(team, n_games) %>% 
-    inner_join(n_blowouts, by = "team") %>% 
+  n_blowouts_to_remove <-
+    scores_joined %>%
+    rowwise() %>%
+    distinct(team, n_games) %>%
+    inner_join(n_blowouts, by = "team") %>%
     mutate(
-      n_blowouts_to_remove = 
+      n_blowouts_to_remove =
         case_when(
           # Need to have at least 5 games that aren't blowouts
           # Remove fewer than all the blowouts if we won't be left with 5 games
           n_games > 5 & n_blowouts > 0 ~ min(n_games - 5, n_blowouts),
           TRUE ~ 0
         )
-    ) %>% 
-    filter(n_blowouts_to_remove > 0) %>% 
+    ) %>%
+    filter(n_blowouts_to_remove > 0) %>%
     ungroup()
-  
+
   # Dataframe of blowout games to get rid of
-  blowouts_to_remove <- 
+  blowouts_to_remove <-
     if (nrow(n_blowouts_to_remove) > 0) {
-      scores_joined %>% 
-        inner_join(n_blowouts_to_remove, by = c("team", "n_games")) %>% 
-        filter(blowout) %>% 
-        select(team, n_blowouts_to_remove, game_number, rating_game) %>% 
+      scores_joined %>%
+        inner_join(n_blowouts_to_remove, by = c("team", "n_games")) %>%
+        filter(blowout) %>%
+        select(
+          team,
+          n_blowouts_to_remove,
+          game_number,
+          rating_game
+        ) %>%
         # Worst games for our team to the top so that these get removed first
-        arrange(team, rating_game) %>% 
-        group_by(team) %>% 
-        slice(1:n_blowouts_to_remove) %>% 
+        arrange(team, rating_game) %>%
+        group_by(team) %>%
+        slice(1:n_blowouts_to_remove) %>%
         ungroup()
     } else {
       tibble(team = character(), game_number = integer())
     }
-  
-  message(glue::glue("Removing {nrow(blowouts_to_remove)} blowout games."))
-  
+
+  message(
+    glue::glue(
+      "Removing {nrow(blowouts_to_remove)} blowout games."
+    )
+  )
+
   # Use the `game_number` to remove blowouts
-  scores_filtered <- 
-    scores_joined %>% 
+  scores_filtered <-
+    scores_joined %>%
     anti_join(blowouts_to_remove, by = c("game_number", "team"))
-  
+
   # Re-calc the team average ratings
-  ratings_new <- 
-    scores_filtered %>% 
-    group_by(team) %>% 
+  ratings_new <-
+    scores_filtered %>%
+    group_by(team) %>%
     summarise(
       rating_team = rating_game %>% weighted.mean(weight) %>% round()
-    ) %>% 
-    arrange(desc(rating_team)) 
-  
+    ) %>%
+    arrange(desc(rating_team))
+
   # Add ranking number
-  rankings_new <- 
-    ratings_new %>% 
+  rankings_new <-
+    ratings_new %>%
     mutate(
       rank = row_number()
     )
-  
+
   print(ratings_new)
-  
+
   i <- i + 1
 }
 
 rankings <- rankings_new
 
-readr::write_csv(rankings, glue::glue(here::here("rankings/rankings.csv")))
-
+readr::write_csv(
+  rankings,
+  glue::glue(here::here("rankings/rankings.csv"))
+)

--- a/rankings/rating.R
+++ b/rankings/rating.R
@@ -218,7 +218,7 @@ while (i < max_iterations & !identical(
     # Attach each opponent's ratings from the last iteration
     inner_join(
       ratings_old %>%
-        rename(
+        select(
           rating_opponent = rating_team,
           opponent = team
         ),
@@ -226,7 +226,11 @@ while (i < max_iterations & !identical(
     ) %>%
     # Attach team's latest rating for blowout rule calc & n games
     inner_join(
-      ratings_old,
+      ratings_old %>%
+        select(
+          team,
+          rating_team
+        ),
       by = "team"
     ) %>%
     # Get the latest game rating given the new opponent team rating

--- a/rankings/rating.R
+++ b/rankings/rating.R
@@ -240,10 +240,8 @@ while (i < max_iterations & !between(mean_ratings_diff, .9999, 1.0001)) {
       # each team's new rating
       blowout =
         case_when(
-          # TODO: figure out if this should also be
-          # `rating_team - rating_opponent < -600` (aka when your team is way
-          # worse than the other team do we still count the blowout)
-          rating_team - rating_opponent > 600 & blowout_score ~ TRUE,
+          abs(rating_team - rating_opponent) > 600 & blowout_score ~
+            TRUE,
           TRUE ~ FALSE
         )
     )

--- a/rankings/scores.csv
+++ b/rankings/scores.csv
@@ -1,4 +1,33 @@
 team_1,team_2,score_1,score_2,event,date
+Firewheel,Inferno,15,7,Bat City Bash 2023,2023-08-12
+Vengeance,Inferno,15,1,Bat City Bash 2023,2023-08-12
+Vengeance,Firewheel,15,1,Bat City Bash 2023,2023-08-12
+KnoxFusion,San Antonio Problems,12,9,HoDown Showdown 2023,2023-08-12
+Juice Box,Magma,15,6,HoDown Showdown 2023,2023-08-12
+Shiver,Calypso,14,6,HoDown Showdown 2023,2023-08-12
+KnoxFusion,Juice Box,5,15,HoDown Showdown 2023,2023-08-12
+San Antonio Problems,Shiver,12,8,HoDown Showdown 2023,2023-08-12
+Magma,Calypso,9,10,HoDown Showdown 2023,2023-08-12
+KnoxFusion,Shiver,6,12,HoDown Showdown 2023,2023-08-12
+Juice Box,Calypso,13,6,HoDown Showdown 2023,2023-08-12
+San Antonio Problems,Magma,10,8,HoDown Showdown 2023,2023-08-12
+KnoxFusion,Calypso,10,12,HoDown Showdown 2023,2023-08-12
+Juice Box,San Antonio Problems,14,8,HoDown Showdown 2023,2023-08-12
+Shiver,Magma,12,8,HoDown Showdown 2023,2023-08-12
+KnoxFusion,Magma,11,10,HoDown Showdown 2023,2023-08-12
+Juice Box,Shiver,7,10,HoDown Showdown 2023,2023-08-12
+San Antonio Problems,Calypso,15,6,HoDown Showdown 2023,2023-08-12
+Shiver,San Antonio Problems,11,9,HoDown Showdown 2023,2023-08-12
+Shiver,Calypso,13,6,HoDown Showdown 2023,2023-08-12
+Juice Box,San Antonio Problems,10,15,HoDown Showdown 2023,2023-08-12
+Calypso,Juice Box,8,9,HoDown Showdown 2023,2023-08-12
+KnoxFusion,Magma,3,7,HoDown Showdown 2023,2023-08-12
+Siege,Iris,11,10,Log Jam,2023-08-12
+Starling Ultimate,Iris,10,7,Log Jam,2023-08-12
+Starling Ultimate,Siege,10,9,Log Jam,2023-08-12
+Siege,Iris,8,13,Log Jam,2023-08-12
+Starling Ultimate,Iris,11,10,Log Jam,2023-08-12
+Starling Ultimate,Iris,6,11,Log Jam,2023-08-12
 Wave,Vice,9,10,Philly Open 2023,2023-08-05
 Pine Baroness,Dissent,13,2,Philly Open 2023,2023-08-05
 Incline,Versa,10,7,Philly Open 2023,2023-08-05


### PR DESCRIPTION
This PR makes a few changes to improve alignment with the [USA Ultimate Rankings Algorithm](https://play.usaultimate.org/teams/events/rankings/#algorithm). Specifically, that includes:

- Removing blowouts for losing teams (8a384385c669860acc4037a8d7227342650194c9)
- Removing blowouts for losing teams with fewer than 5 countable games, as long as the winning team had 5 countable games (709b1bbffe1e5e7c3e06ef5f5b10ffca4c410f74)
- Using an exponential date weight ramp (0a321799eaca0f8f193b3620d87d3a43d4a185cc)
- Iterating through the algorithm until ratings (rather than rankings) stabilize within an average of 0.01% of iteration-over-iteration change (e91c27643389dcd370c54b3bc23fcfeb388ff657)

I also used `rankings/scrape.R` to rope in some more tourneys (8a18a0793652ec958e518833f144d3492400aad1), updated `rankings/rankings.csv` with the new final output of `rankings/rating.R` (3629ca8233a64d4a25008da24295105fc286f70c), and simplified some of the existing blowout code (a8f454348bc3a42e783b776a86a832b06e5770d4).

Finally, my autostyler also created a bunch of unnecessary styling changes that I had a hard time undoing... oops!